### PR TITLE
chainable constructions and Time-to-string conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ The `outgoing_mapping_config` is a JSON Object and used to provide information a
 | map_all                | If true, all properties are mapped              |
 | custom                 | A map of custom config keys and values          |
 
-Outgoing mappings define optional constructors and mappings. Constructors are functions that can create new properties before any mapping is applied. This can be used, for example, to concatenate multiple properties into a single property. The constructors are defined as follows:
+Outgoing mappings define optional constructions and mappings. Constructions are functions that can create new properties
+before any mapping is applied. This can be used, for example, to concatenate multiple properties into a single property.
+A constructor is defined as follows:
 
 | JSON Field | Description                       |
 |------------|-----------------------------------|
@@ -171,6 +173,43 @@ Here is a sample constructor definition:
     ]
 }
 ```
+
+Constructions override exiting properties if property names are the same.
+
+If multiple constructions are defined, they are applied in the order they are defined.
+
+Newly constructed properties can also be used as input property in succeeding constructions. This way multiple
+constructions can be composed into complex transformations.
+
+The following example uses these construction semantics to combine multiple constructors and create a formatted
+full name property
+
+``` json
+{
+    "property": "separator",
+    "operation": "literal",
+    "args": [ " " ]
+},
+{
+    "property": "prefixedLastName",
+    "operation": "concat",
+    "args": [
+        "separator",
+        "lastName"
+    ]
+},
+{
+    "property": "fullName",
+    "operation": "concat",
+    "args": [
+        "firstName",
+        "prefixedLastName"
+    ]
+}
+``` 
+
+
+
 After any constructors the mappings are applied, they are defined as follows:
 
 | Field Name        | Description                                         |

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ Here is a sample constructor definition:
 }
 ```
 
-Constructions override exiting properties if property names are the same.
+Constructions override existing properties if property names are the same.
 
-If multiple constructions are defined, they are applied in the order they are defined.
+When multiple constructions are defined, they are applied in the order they appear in configuration.
 
 Newly constructed properties can also be used as input property in succeeding constructions. This way multiple
 constructions can be composed into complex transformations.
@@ -185,7 +185,7 @@ The following example uses these construction semantics to combine multiple cons
 full name property
 
 ``` json
-{
+[{
     "property": "separator",
     "operation": "literal",
     "args": [ " " ]
@@ -205,7 +205,7 @@ full name property
         "firstName",
         "prefixedLastName"
     ]
-}
+}]
 ``` 
 
 

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -1,6 +1,7 @@
 package common_datalayer
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -302,8 +303,9 @@ func TestMapOutgoingItemWithPropertyMappingOfDifferentTypes(t *testing.T) {
 		t.Error("entity property ratings should be [1.0, 5.0]")
 	}
 
-	if entity.References["http://data.example.com/when"] != "http://data.example.com/when/2023-12-20T10:06:39+01:00" {
-		t.Error("entity reference when should be http://data.example.com/when/2023-12-20T10:06:39+01:00, was ",
+	expectedTime := time.Unix(1703063199, 0).Format(time.RFC3339)
+	if entity.References["http://data.example.com/when"] != "http://data.example.com/when/"+expectedTime {
+		t.Error("entity reference when should be http://data.example.com/when/"+expectedTime+", was ",
 			entity.References["http://data.example.com/when"])
 	}
 }
@@ -371,8 +373,12 @@ func TestMapOutgoingWithChainedConstructions(t *testing.T) {
 		t.Error(err)
 	}
 
-	if entity.ID != "http://data.example.com/id/BIRTHDAY-2023_12_20T10_06_39_01_00" {
-		t.Error("entity ID should be http://data.example.com/id/BIRTHDAY-2023_12_20T10_06_39_01_00. was ", entity.ID)
+	expectedTime := time.Unix(1703063199, 0).Format(time.RFC3339)
+	expectedTime = strings.ReplaceAll(expectedTime, ":", "_")
+	expectedTime = strings.ReplaceAll(expectedTime, "-", "_")
+	expectedTime = strings.ReplaceAll(expectedTime, "+", "_")
+	if entity.ID != "http://data.example.com/id/BIRTHDAY-"+expectedTime {
+		t.Error("entity ID should be http://data.example.com/id/BIRTHDAY-"+expectedTime+". was ", entity.ID)
 	}
 
 }

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -2,6 +2,7 @@ package common_datalayer
 
 import (
 	"testing"
+	"time"
 
 	egdm "github.com/mimiro-io/entity-graph-data-model"
 )
@@ -253,6 +254,12 @@ func TestMapOutgoingItemWithPropertyMappingOfDifferentTypes(t *testing.T) {
 			EntityProperty: "http://data.example.com/height",
 		},
 		&ItemToEntityPropertyMapping{
+			Property:        "when",
+			IsReference:     true,
+			EntityProperty:  "http://data.example.com/when",
+			URIValuePattern: "http://data.example.com/when/{value}",
+		},
+		&ItemToEntityPropertyMapping{
 			Property:        "id",
 			IsIdentity:      true,
 			URIValuePattern: "http://data.example.com/{value}",
@@ -265,6 +272,7 @@ func TestMapOutgoingItemWithPropertyMappingOfDifferentTypes(t *testing.T) {
 	item.SetValue("tags", []string{"marge", "simpson"})
 	item.SetValue("ratings", []float64{1.0, 5.0})
 	item.SetValue("id", "1")
+	item.SetValue("when", time.Unix(1703063199, 0))
 
 	mapper := NewMapper(logger, nil, outgoingConfig)
 
@@ -293,6 +301,79 @@ func TestMapOutgoingItemWithPropertyMappingOfDifferentTypes(t *testing.T) {
 	if entity.Properties["http://data.example.com/ratings"].([]float64)[0] != 1.0 {
 		t.Error("entity property ratings should be [1.0, 5.0]")
 	}
+
+	if entity.References["http://data.example.com/when"] != "http://data.example.com/when/2023-12-20T10:06:39+01:00" {
+		t.Error("entity reference when should be http://data.example.com/when/2023-12-20T10:06:39+01:00")
+	}
+}
+
+func TestMapOutgoingWithChainedConstructions(t *testing.T) {
+	logger := newLogger("testService", "text")
+
+	mapper := NewMapper(logger, nil, &OutgoingMappingConfig{
+		Constructions: []*PropertyConstructor{
+			{
+				PropertyName: "what",
+				Operation:    "trim",
+				Arguments:    []string{"what"},
+			},
+			{
+				PropertyName: "what",
+				Operation:    "toupper",
+				Arguments:    []string{"what"},
+			},
+			{
+				PropertyName: "dash",
+				Operation:    "literal",
+				Arguments:    []string{"-"},
+			},
+			{
+				PropertyName: "what",
+				Operation:    "concat",
+				Arguments:    []string{"what", "dash"},
+			},
+			{
+				PropertyName: "when",
+				Operation:    "replace",
+				Arguments:    []string{"when", "-", "_"},
+			},
+			{
+				PropertyName: "when",
+				Operation:    "replace",
+				Arguments:    []string{"when", ":", "_"},
+			},
+			{
+				PropertyName: "when",
+				Operation:    "replace",
+				Arguments:    []string{"when", "+", "_"},
+			},
+			{
+				PropertyName: "id",
+				Operation:    "concat",
+				Arguments:    []string{"what", "when"},
+			},
+		},
+		PropertyMappings: []*ItemToEntityPropertyMapping{{
+			Property:        "id",
+			URIValuePattern: "http://data.example.com/id/{value}",
+			IsIdentity:      true,
+		}}})
+
+	// make the item
+	item := &InMemoryItem{properties: make(map[string]interface{}), propertyNames: make([]string, 0)}
+	item.SetValue("what", "   Birthday ")
+	item.SetValue("when", time.Unix(1703063199, 0))
+
+	entity := egdm.NewEntity()
+	err := mapper.MapItemToEntity(item, entity)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if entity.ID != "http://data.example.com/id/BIRTHDAY-2023_12_20T10_06_39_01_00" {
+		t.Error("entity ID should be http://data.example.com/id/BIRTHDAY-2023_12_20T10_06_39_01_00")
+	}
+
 }
 
 // test missing property defined as required

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -303,7 +303,8 @@ func TestMapOutgoingItemWithPropertyMappingOfDifferentTypes(t *testing.T) {
 	}
 
 	if entity.References["http://data.example.com/when"] != "http://data.example.com/when/2023-12-20T10:06:39+01:00" {
-		t.Error("entity reference when should be http://data.example.com/when/2023-12-20T10:06:39+01:00")
+		t.Error("entity reference when should be http://data.example.com/when/2023-12-20T10:06:39+01:00, was ",
+			entity.References["http://data.example.com/when"])
 	}
 }
 
@@ -371,7 +372,7 @@ func TestMapOutgoingWithChainedConstructions(t *testing.T) {
 	}
 
 	if entity.ID != "http://data.example.com/id/BIRTHDAY-2023_12_20T10_06_39_01_00" {
-		t.Error("entity ID should be http://data.example.com/id/BIRTHDAY-2023_12_20T10_06_39_01_00")
+		t.Error("entity ID should be http://data.example.com/id/BIRTHDAY-2023_12_20T10_06_39_01_00. was ", entity.ID)
 	}
 
 }


### PR DESCRIPTION
This change introduces two improvements for outgoing mappings (reading from layer):

1. support for using time.Time item values in places that require string. e.g. UriPatterns, various constructions like concat, replace etc. The mapper will now autoconvert time.Time values to ISO8601 string format for this purpose
2. ability to chain multiple constructions together for more options when composing values. See included unit test for possible usage benefits