### PR TITLE
feat: add formatted logging methods

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -23,9 +23,13 @@ type Metrics interface {
 
 type Logger interface {
 	Error(message string, args ...any)
+	Errorf(format string, args ...any)
 	Info(message string, args ...any)
+	Infof(format string, args ...any)
 	Debug(message string, args ...any)
+	Debugf(format string, args ...any)
 	Warn(message string, args ...any)
+	Warnf(format string, args ...any)
 	With(name string, value string) Logger
 }
 
@@ -78,16 +82,32 @@ func (l *logger) Warn(message string, args ...any) {
 	l.log.Warn().Fields(args).Msg(message)
 }
 
+func (l *logger) Warnf(format string, args ...any) {
+	l.log.Warn().Msgf(format, args...)
+}
+
 func (l *logger) Error(message string, args ...any) {
 	l.log.Error().Fields(args).Msg(message)
+}
+
+func (l *logger) Errorf(format string, args ...any) {
+	l.log.Error().Msgf(format, args...)
 }
 
 func (l *logger) Info(message string, args ...any) {
 	l.log.Info().Fields(args).Msg(message)
 }
 
+func (l *logger) Infof(format string, args ...any) {
+	l.log.Info().Msgf(format, args...)
+}
+
 func (l *logger) Debug(message string, args ...any) {
 	l.log.Debug().Fields(args).Msg(message)
+}
+
+func (l *logger) Debugf(format string, args ...any) {
+	l.log.Debug().Msgf(format, args...)
 }
 
 func NewLogger(serviceName string, format string, level string) Logger {

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,37 @@
+package common_datalayer
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestLoggerFormattedMethods(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := &logger{log: zerolog.New(buf)}
+
+	l.Debugf("debug %s", "msg")
+	if got := buf.String(); !strings.Contains(got, "\"level\":\"debug\"") || !strings.Contains(got, "debug msg") {
+		t.Fatalf("unexpected debugf output: %s", got)
+	}
+	buf.Reset()
+
+	l.Infof("info %s", "msg")
+	if got := buf.String(); !strings.Contains(got, "\"level\":\"info\"") || !strings.Contains(got, "info msg") {
+		t.Fatalf("unexpected infof output: %s", got)
+	}
+	buf.Reset()
+
+	l.Warnf("warn %s", "msg")
+	if got := buf.String(); !strings.Contains(got, "\"level\":\"warn\"") || !strings.Contains(got, "warn msg") {
+		t.Fatalf("unexpected warnf output: %s", got)
+	}
+	buf.Reset()
+
+	l.Errorf("error %s", "msg")
+	if got := buf.String(); !strings.Contains(got, "\"level\":\"error\"") || !strings.Contains(got, "error msg") {
+		t.Fatalf("unexpected errorf output: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- support Debugf/Infof/Warnf/Errorf in logger
- test formatted log output for each level

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d7a17ca00832c82c3f40f6f2e1685