### PR TITLE
feat: add extensive logging

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	config, err := loadConfig("./testdata")
+	logger := NewLogger("test", "text", "debug")
+	config, err := loadConfig("./testdata", logger)
 	if err != nil {
 		t.Error(err)
 	}
@@ -27,7 +28,8 @@ func TestConfig_AddEnvOverrides(t *testing.T) {
 	t.Setenv("LOG_LEVEL", "debug")
 	t.Setenv("LOG_FORMAT", "json")
 
-	config, err := loadConfig("./testdata")
+	logger := NewLogger("test", "text", "debug")
+	config, err := loadConfig("./testdata", logger)
 	if err != nil {
 		t.Error(err)
 	}

--- a/config_updater.go
+++ b/config_updater.go
@@ -48,9 +48,11 @@ func newConfigUpdater(
 		var err error
 		interval, err = asDuration(config.LayerServiceConfig.ConfigRefreshInterval)
 		if err != nil {
+			l.Error("Invalid config refresh interval", "error", err.Error())
 			return nil, err
 		}
 	}
+	l.Info("Starting config updater", "interval", interval.String())
 	u.ticker = time.NewTicker(interval)
 	u.config = config
 
@@ -64,7 +66,7 @@ func newConfigUpdater(
 
 func (u *configUpdater) checkForUpdates(enrichConfig func(config *Config) error, logger Logger, listeners ...DataLayerService) {
 	logger.Debug("checking config for updates in " + u.config.ConfigPath + ".")
-	loadedConf, err := loadConfig(u.config.ConfigPath)
+	loadedConf, err := loadConfig(u.config.ConfigPath, logger)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to load config: %v", err.Error()))
 		return

--- a/encoder/common.go
+++ b/encoder/common.go
@@ -9,8 +9,10 @@ import (
 func NewItemIterator(sourceConfig map[string]any, logger cdl.Logger, data io.ReadCloser) (ItemIterator, error) {
 	encoding, ok := sourceConfig["encoding"]
 	if !ok {
+		logger.Error("no encoding specified in source config")
 		return nil, errors.New("no encoding specified in source config")
 	}
+	logger.Debug("Creating item iterator", "encoding", encoding)
 	if encoding == "json" {
 		return NewJsonItemIterator(sourceConfig, logger, data)
 	}
@@ -27,8 +29,10 @@ func NewItemIterator(sourceConfig map[string]any, logger cdl.Logger, data io.Rea
 func NewItemWriter(sourceConfig map[string]any, logger cdl.Logger, data io.WriteCloser, batchInfo *cdl.BatchInfo) (ItemWriter, error) {
 	encoding, ok := sourceConfig["encoding"]
 	if !ok {
+		logger.Error("no encoding specified in source config")
 		return nil, errors.New("no encoding specified in source config")
 	}
+	logger.Debug("Creating item writer", "encoding", encoding)
 
 	if encoding == "json" {
 		return NewJsonItemWriter(sourceConfig, logger, data, batchInfo)

--- a/service.go
+++ b/service.go
@@ -26,6 +26,11 @@ func NewServiceRunner(newLayerService func(config *Config, logger Logger, metric
 }
 
 func (serviceRunner *ServiceRunner) configure() {
+	if serviceRunner.logger == nil {
+		// bootstrap logger before config is available
+		serviceRunner.logger = NewLogger("bootstrap", "text", "info")
+	}
+
 	if serviceRunner.configLocation == "" {
 		configPath, found := os.LookupEnv("DATALAYER_CONFIG_PATH")
 		if found {
@@ -35,15 +40,20 @@ func (serviceRunner *ServiceRunner) configure() {
 		}
 	}
 
-	config, err := loadConfig(serviceRunner.configLocation)
+	serviceRunner.logger.Debug("Loading configuration", "path", serviceRunner.configLocation)
+	config, err := loadConfig(serviceRunner.configLocation, serviceRunner.logger)
 	if err != nil {
+		serviceRunner.logger.Error("Failed to load configuration", "error", err.Error())
 		panic(err)
 	}
+	serviceRunner.logger.Info("Configuration loaded")
 
 	// enrich config specific for layer
 	if serviceRunner.enrichConfig != nil {
+		serviceRunner.logger.Debug("Enriching configuration")
 		err = serviceRunner.enrichConfig(config)
 		if err != nil {
+			serviceRunner.logger.Error("Failed to enrich configuration", "error", err.Error())
 			panic(err)
 		}
 	}
@@ -55,34 +65,44 @@ func (serviceRunner *ServiceRunner) configure() {
 		config.LayerServiceConfig.LogLevel,
 	)
 	serviceRunner.logger = logger
+	serviceRunner.logger.Info("Logger initialised", "level", config.LayerServiceConfig.LogLevel, "format", config.LayerServiceConfig.LogFormat)
 
 	metrics, err := newMetrics(config)
 	if err != nil {
+		serviceRunner.logger.Error("Failed to initialise metrics", "error", err.Error())
 		panic(err)
 	}
+	serviceRunner.logger.Info("Metrics initialised")
 
 	serviceRunner.layerService, err = serviceRunner.createService(config, logger, metrics)
 	if err != nil {
+		serviceRunner.logger.Error("Failed to create data layer service", "error", err.Error())
 		panic(err)
 	}
+	serviceRunner.logger.Info("Data layer service created")
 
 	// create and start config updater
 	serviceRunner.configUpdater, err = newConfigUpdater(config, serviceRunner.enrichConfig, logger, serviceRunner.layerService)
 	if err != nil {
+		serviceRunner.logger.Error("Failed to start config updater", "error", err.Error())
 		panic(err)
 	}
+	serviceRunner.logger.Info("Config updater started")
 
 	// create web service hook up with the service core
 	serviceRunner.webService, err = newDataLayerWebService(config, logger, metrics, serviceRunner.layerService)
 	if err != nil {
+		serviceRunner.logger.Error("Failed to create web service", "error", err.Error())
 		panic(err)
 	}
+	serviceRunner.logger.Info("Web service created")
 
 	serviceRunner.stoppable = append(
 		serviceRunner.stoppable,
 		serviceRunner.layerService,
 		serviceRunner.configUpdater,
 		serviceRunner.webService)
+	serviceRunner.logger.Debug("Service configuration complete")
 }
 
 type ServiceRunner struct {
@@ -101,42 +121,60 @@ func (serviceRunner *ServiceRunner) LayerService() DataLayerService {
 }
 
 func (serviceRunner *ServiceRunner) Start() error {
+	if serviceRunner.logger == nil {
+		serviceRunner.logger = NewLogger("bootstrap", "text", "info")
+	}
+	serviceRunner.logger.Info("Starting service")
 	// configure the service
 	serviceRunner.configure()
 
 	// start the service
 	err := serviceRunner.webService.Start()
 	if err != nil {
+		serviceRunner.logger.Error("Failed to start web service", "error", err.Error())
 		return err
 	}
+	serviceRunner.logger.Info("Service started")
 
 	return nil
 }
 
 func (serviceRunner *ServiceRunner) StartAndWait() {
+	if serviceRunner.logger == nil {
+		serviceRunner.logger = NewLogger("bootstrap", "text", "info")
+	}
+	serviceRunner.logger.Info("Starting service and waiting for shutdown")
 	// configure the service
 	serviceRunner.configure()
 
 	// start the service
 	err := serviceRunner.webService.Start()
 	if err != nil {
+		serviceRunner.logger.Error("Failed to start web service", "error", err.Error())
 		panic(err)
 	}
+	serviceRunner.logger.Info("Service started, entering wait state")
 
 	// and wait for ctrl-c
 	serviceRunner.andWait()
 }
 
 func (serviceRunner *ServiceRunner) Stop() error {
+	if serviceRunner.logger == nil {
+		serviceRunner.logger = NewLogger("bootstrap", "text", "info")
+	}
+	serviceRunner.logger.Info("Stopping service")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	for _, stoppable := range serviceRunner.stoppable {
 		err := stoppable.Stop(ctx)
 		if err != nil {
+			serviceRunner.logger.Error("Failed to stop component", "error", err.Error())
 			return err
 		}
 	}
 
+	serviceRunner.logger.Info("Service stopped")
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add detailed logging to configuration loading and environment overrides
- instrument service runner, config updater, mapper and encoders with info/debug/warn/error logs
- drop redundant logger nil checks to assume logger is always provided

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d8b812eec832caa8e0d9be36456b6